### PR TITLE
Remove ansi for c++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,9 +43,9 @@ if(NOT COMPILER_SUPPORTS_CXX_FLAGS)
 endif()
 
 if(APPLE)
-    set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -pedantic -Wno-long-long -Wno-sign-compare -Wshadow -fno-strict-aliasing ${CMAKE_CXX_FLAGS}")
-else()
-    set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -ansi -pedantic -Wno-long-long -Wno-sign-compare -Wshadow -fno-strict-aliasing ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic -Wno-long-long -Wno-sign-compare -Wshadow -fno-strict-aliasing ${CMAKE_CXX_FLAGS}")
+else(
+    set(CMAKE_CXX_FLAGS "-Wall -Wextra -pedantic -Wno-long-long -Wno-sign-compare -Wshadow -fno-strict-aliasing ${CMAKE_CXX_FLAGS}")
 endif()
 
 #-------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Remove the -ansi -Werror flag. ansi interferes with c++11 and Werror makes problems in compilation.
