### PR TITLE
EventWriting|Reading algorithms: Make members protected so we can inherit

### DIFF
--- a/include/Objects/Track.h
+++ b/include/Objects/Track.h
@@ -199,7 +199,7 @@ protected:
     /**
      *  @brief  Constructor
      * 
-     *  @param  parameters the calo hit parameters
+     *  @param  parameters the track parameters
      */
     Track(const object_creation::Track::Parameters &parameters);
 

--- a/include/Persistency/EventReadingAlgorithm.h
+++ b/include/Persistency/EventReadingAlgorithm.h
@@ -54,7 +54,7 @@ public:
         pandora::InputUInt      m_skipToEvent;                  ///< Index of first event to consider in input file
     };
 
-private:
+protected:
     pandora::StatusCode Initialize();
     pandora::StatusCode Run();
 

--- a/include/Persistency/EventWritingAlgorithm.h
+++ b/include/Persistency/EventWritingAlgorithm.h
@@ -41,7 +41,7 @@ public:
      */
     ~EventWritingAlgorithm();
 
-private:
+protected:
     pandora::StatusCode Initialize();
     pandora::StatusCode Run();
     pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);


### PR DESCRIPTION
This allows one to inherit from these algorithms and just extend with the needed functionality

I think this is needed for PandoraPFA/LCContent#17


(also fix doc-string for track parameters)