### PR TITLE
PandoraInternal.h: #include <cstdint> for uintptr_t in e.g. gcc-13

### DIFF
--- a/include/Pandora/PandoraInternal.h
+++ b/include/Pandora/PandoraInternal.h
@@ -9,6 +9,7 @@
 #define PANDORA_INTERNAL_H 1
 
 #include <algorithm>
+#include <cstdint>
 #include <iostream>
 #include <iomanip>
 #include <list>


### PR DESCRIPTION
This is a small (and sufficient) bugfix needed to build PandoraSDK with gcc-13. The `cstdint` does not get included transitively anymore, causing undefined `uintptr_t` in `PandoraInternal.h`.

Note that `cstdint` has been around since C++11, so with a targeted standard of C++17 here, this does not add any new headers that are only expected to exist in newer C++ standards.