### PR TITLE
Don't use assignment in if statements

### DIFF
--- a/include/Helpers/ClusterFitHelper.h
+++ b/include/Helpers/ClusterFitHelper.h
@@ -411,7 +411,8 @@ inline void ClusterFitResult::SetIntercept(const CartesianVector &intercept)
 
 inline void ClusterFitResult::SetChi2(const float chi2)
 {
-    if (!(m_chi2 = chi2))
+    m_chi2 = chi2;
+    if (!m_chi2)
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 }
 
@@ -419,7 +420,8 @@ inline void ClusterFitResult::SetChi2(const float chi2)
 
 inline void ClusterFitResult::SetRms(const float rms)
 {
-    if (!(m_rms = rms))
+    m_rms = rms
+    if (!m_rms)
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 }
 
@@ -427,7 +429,8 @@ inline void ClusterFitResult::SetRms(const float rms)
 
 inline void ClusterFitResult::SetRadialDirectionCosine(const float radialDirectionCosine)
 {
-    if (!(m_dirCosR = radialDirectionCosine))
+    m_dirCosR = radialDirectionCosine
+    if (!m_dirCosR)
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 }
 


### PR DESCRIPTION
For some reason this construct triggers a `-Werror=parentheses` specifically for one build I have on EL9 with gcc13.1. Technically, I think the compiler is wrong here, by actually flagging this, but on the other hand it is a pretty straight forward fix that should always work.