### PR TITLE
Move assignments outside of if statement

### DIFF
--- a/include/Helpers/ClusterFitHelper.h
+++ b/include/Helpers/ClusterFitHelper.h
@@ -411,7 +411,8 @@ inline void ClusterFitResult::SetIntercept(const CartesianVector &intercept)
 
 inline void ClusterFitResult::SetChi2(const float chi2)
 {
-    if (!(m_chi2 = chi2))
+    m_chi2 = chi2;
+    if (!m_chi2.IsInitialized())
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 }
 
@@ -419,7 +420,8 @@ inline void ClusterFitResult::SetChi2(const float chi2)
 
 inline void ClusterFitResult::SetRms(const float rms)
 {
-    if (!(m_rms = rms))
+    m_rms = rms;
+    if (!m_rms.IsInitialized())
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 }
 
@@ -427,7 +429,8 @@ inline void ClusterFitResult::SetRms(const float rms)
 
 inline void ClusterFitResult::SetRadialDirectionCosine(const float radialDirectionCosine)
 {
-    if (!(m_dirCosR = radialDirectionCosine))
+    m_dirCosR = radialDirectionCosine;
+    if (!m_dirCosR.IsInitialized())
         throw StatusCodeException(STATUS_CODE_INVALID_PARAMETER);
 }
 

--- a/src/Objects/CaloHit.cc
+++ b/src/Objects/CaloHit.cc
@@ -146,7 +146,8 @@ StatusCode CaloHit::AlterMetadata(const object_creation::CaloHit::Metadata &meta
 
 StatusCode CaloHit::SetPseudoLayer(const unsigned int pseudoLayer)
 {
-    if (!(m_pseudoLayer = pseudoLayer))
+    m_pseudoLayer = pseudoLayer;
+    if (!m_pseudoLayer.IsInitialized())
         return STATUS_CODE_NOT_INITIALIZED;
 
     return STATUS_CODE_SUCCESS;

--- a/src/Objects/Cluster.cc
+++ b/src/Objects/Cluster.cc
@@ -525,7 +525,8 @@ void Cluster::UpdatePhotonIdCache(const Pandora &pandora) const
 {
     const bool passPhotonId(pandora.GetPlugins()->GetParticleId()->IsPhoton(this));
 
-    if (!(m_passPhotonId = passPhotonId))
+    m_passPhotonId = passPhotonId;
+    if (!m_passPhotonId.IsInitialized())
         throw StatusCodeException(STATUS_CODE_FAILURE);
 }
 
@@ -538,7 +539,8 @@ void Cluster::UpdateShowerLayerCache(const Pandora &pandora) const
     unsigned int showerStartLayer(std::numeric_limits<unsigned int>::max());
     pShowerProfilePlugin->CalculateShowerStartLayer(this, showerStartLayer);
 
-    if (!(m_showerStartLayer = showerStartLayer))
+    m_showerStartLayer = showerStartLayer;
+    if (!m_showerStartLayer.IsInitialized())
         throw StatusCodeException(STATUS_CODE_FAILURE);
 }
 
@@ -551,7 +553,10 @@ void Cluster::UpdateShowerProfileCache(const Pandora &pandora) const
     float showerProfileStart(std::numeric_limits<float>::max()), showerProfileDiscrepancy(std::numeric_limits<float>::max());
     pShowerProfilePlugin->CalculateLongitudinalProfile(this, showerProfileStart, showerProfileDiscrepancy);
 
-    if (!(m_showerProfileStart = showerProfileStart) || !(m_showerProfileDiscrepancy = showerProfileDiscrepancy))
+
+    m_showerProfileStart = showerProfileStart;
+    m_showerProfileDiscrepancy = showerProfileDiscrepancy;
+    if (!m_showerProfileStart.IsInitialized() || !m_showerProfileDiscrepancy.IsInitialized())
         throw StatusCodeException(STATUS_CODE_FAILURE);
 }
 


### PR DESCRIPTION
Starting from version 13, gcc starts warning about this construct **only if it's negated** and when building with `-std=c++20`. No warning is raised with `-std=c++17` or when using gcc12 ([see mini demonstrator no compiler explorer with gcc12 and gcc13](https://godbolt.org/z/9Kv13199v)).

Explicitly lifting out the result of the assignment into a variable and checking that explicitly gets around this.

I will try to figure out whether the fact, that this works for `if ((a = b))`, but not for `if (!(a = b))` is a gcc bug or expected behavior.

This is, I think the better way to fix what I attempted in #17 