### PR TITLE
MCParticleWeights are now of type pandora::InputFloat.

### DIFF
--- a/include/Api/PandoraApi.h
+++ b/include/Api/PandoraApi.h
@@ -115,7 +115,7 @@ public:
      *  @param  mcParticleWeight weighting to assign to the mc particle
      */
     static pandora::StatusCode SetCaloHitToMCParticleRelationship(const pandora::Pandora &pandora, const void *const pCaloHitParentAddress,
-        const void *const pMCParticleParentAddress, const float mcParticleWeight = 1);
+        const void *const pMCParticleParentAddress, const pandora::InputFloat mcParticleWeight = 1.f);
 
     /**
      *  @brief  Set track to mc particle relationship
@@ -126,7 +126,7 @@ public:
      *  @param  mcParticleWeight weighting to assign to the mc particle
      */
     static pandora::StatusCode SetTrackToMCParticleRelationship(const pandora::Pandora &pandora, const void *const pTrackParentAddress,
-        const void *const pMCParticleParentAddress, const float mcParticleWeight = 1);
+        const void *const pMCParticleParentAddress, const pandora::InputFloat mcParticleWeight = 1.f);
 
     /**
      *  @brief  Get the current pfo list

--- a/include/Api/PandoraApiImpl.h
+++ b/include/Api/PandoraApiImpl.h
@@ -92,7 +92,7 @@ private:
      *  @param  mcParticleWeight weighting to assign to the mc particle
      */
     StatusCode SetCaloHitToMCParticleRelationship(const void *const pCaloHitParentAddress, const void *const pMCParticleParentAddress,
-        const float mcParticleWeight) const;
+        const InputFloat mcParticleWeight) const;
 
     /**
      *  @brief  Set track to mc particle relationship
@@ -102,7 +102,7 @@ private:
      *  @param  mcParticleWeight weighting to assign to the mc particle
      */
     StatusCode SetTrackToMCParticleRelationship(const void *const pTrackParentAddress, const void *const pMCParticleParentAddress,
-        const float mcParticleWeight) const;
+        const InputFloat mcParticleWeight) const;
 
     /**
      *  @brief  Get the current pfo list

--- a/src/Api/PandoraApi.cc
+++ b/src/Api/PandoraApi.cc
@@ -66,7 +66,7 @@ pandora::StatusCode PandoraApi::SetTrackSiblingRelationship(const pandora::Pando
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 pandora::StatusCode PandoraApi::SetCaloHitToMCParticleRelationship(const pandora::Pandora &pandora, const void *const pCaloHitParentAddress,
-    const void *const pMCParticleParentAddress, const float mcParticleWeight)
+    const void *const pMCParticleParentAddress, const pandora::InputFloat mcParticleWeight)
 {
     return pandora.GetPandoraApiImpl()->SetCaloHitToMCParticleRelationship(pCaloHitParentAddress, pMCParticleParentAddress, mcParticleWeight);
 }
@@ -74,7 +74,7 @@ pandora::StatusCode PandoraApi::SetCaloHitToMCParticleRelationship(const pandora
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 pandora::StatusCode PandoraApi::SetTrackToMCParticleRelationship(const pandora::Pandora &pandora, const void *const pTrackParentAddress,
-    const void *const pMCParticleParentAddress, const float mcParticleWeight)
+    const void *const pMCParticleParentAddress, const pandora::InputFloat mcParticleWeight)
 {
     return pandora.GetPandoraApiImpl()->SetTrackToMCParticleRelationship(pTrackParentAddress, pMCParticleParentAddress, mcParticleWeight);
 }

--- a/src/Api/PandoraApiImpl.cc
+++ b/src/Api/PandoraApiImpl.cc
@@ -147,17 +147,17 @@ StatusCode PandoraApiImpl::SetTrackSiblingRelationship(const void *const pFirstS
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode PandoraApiImpl::SetCaloHitToMCParticleRelationship(const void *const pCaloHitParentAddress, const void *const pMCParticleParentAddress,
-    const float mcParticleWeight) const
+    const InputFloat mcParticleWeight) const
 {
-    return m_pPandora->m_pMCManager->SetCaloHitToMCParticleRelationship(pCaloHitParentAddress, pMCParticleParentAddress, mcParticleWeight);
+    return m_pPandora->m_pMCManager->SetCaloHitToMCParticleRelationship(pCaloHitParentAddress, pMCParticleParentAddress, mcParticleWeight.Get());
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode PandoraApiImpl::SetTrackToMCParticleRelationship(const void *const pTrackParentAddress, const void *const pMCParticleParentAddress,
-    const float mcParticleWeight) const
+    const InputFloat mcParticleWeight) const
 {
-    return m_pPandora->m_pMCManager->SetTrackToMCParticleRelationship(pTrackParentAddress, pMCParticleParentAddress, mcParticleWeight);
+    return m_pPandora->m_pMCManager->SetTrackToMCParticleRelationship(pTrackParentAddress, pMCParticleParentAddress, mcParticleWeight.Get());
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Switching from built in `float` to `pandora::InputFloat` should protect against invalid NaN/INF MC Particle weights, raising a `pandora::StatusCode` exception if invalid weights are provided.