### PR TITLE
Add the parent address for external clusters and hit types for the dual-readout calorimeter

### DIFF
--- a/include/Objects/Cluster.h
+++ b/include/Objects/Cluster.h
@@ -143,6 +143,11 @@ public:
     unsigned int GetOuterPseudoLayer() const;
 
     /**
+     *  @brief  Get the address of the external cluster in the user framework
+     */
+    const void *GetParentAddress() const;
+
+    /**
      *  @brief  Get unweighted centroid for cluster at a particular pseudo layer, calculated using cached values of hit coordinate sums
      * 
      *  @param  pseudoLayer the pseudo layer of interest
@@ -440,6 +445,7 @@ protected:
     PointByPseudoLayerMap       m_sumXYZByPseudoLayer;          ///< Construct to allow rapid calculation of centroid in each pseudolayer
     InputUInt                   m_innerPseudoLayer;             ///< The innermost pseudo layer in the cluster
     InputUInt                   m_outerPseudoLayer;             ///< The outermost pseudo layer in the cluster
+    const void                 *m_pParentAddress;               ///< The address of the external cluster in the user framework
 
     mutable CartesianVector     m_initialDirection;             ///< The initial direction of the cluster
     mutable bool                m_isDirectionUpToDate;          ///< Whether the initial direction of the cluster is up to date
@@ -568,6 +574,11 @@ inline unsigned int Cluster::GetInnerPseudoLayer() const
 inline unsigned int Cluster::GetOuterPseudoLayer() const
 {
     return m_outerPseudoLayer.Get();
+}
+
+inline const void *Cluster::GetParentAddress() const
+{
+    return m_pParentAddress;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/include/Pandora/ObjectCreation.h
+++ b/include/Pandora/ObjectCreation.h
@@ -324,6 +324,7 @@ public:
     pandora::CaloHitList                m_caloHitList;              ///< The calo hit(s) to include
     pandora::CaloHitList                m_isolatedCaloHitList;      ///< The isolated calo hit(s) to include
     pandora::InputTrackAddress          m_pTrack;                   ///< The address of the track seeding the cluster
+    pandora::InputAddress               m_pParentAddress;           ///< Address of the external cluster in the user framework
 };
 
 typedef ObjectCreationHelper<ClusterParameters, ClusterMetadata, pandora::Cluster> Cluster;

--- a/include/Pandora/PandoraEnumeratedTypes.h
+++ b/include/Pandora/PandoraEnumeratedTypes.h
@@ -71,6 +71,8 @@ enum HitType
     TPC_VIEW_V,
     TPC_VIEW_W,
     TPC_3D,
+    SCINTILLATION,
+    CHERENKOV,
     HIT_CUSTOM
 };
 

--- a/src/Objects/Cluster.cc
+++ b/src/Objects/Cluster.cc
@@ -239,6 +239,7 @@ Cluster::Cluster(const object_creation::Cluster::Parameters &parameters) :
     m_isolatedHadronicEnergy(0),
     m_particleId(UNKNOWN_PARTICLE_TYPE),
     m_pTrackSeed(parameters.m_pTrack.IsInitialized() ? parameters.m_pTrack.Get() : nullptr),
+    m_pParentAddress(parameters.m_pParentAddress.IsInitialized() ? parameters.m_pParentAddress.Get() : nullptr),
     m_initialDirection(0.f, 0.f, 0.f),
     m_isDirectionUpToDate(false),
     m_isFitUpToDate(false),


### PR DESCRIPTION
Hi, recently, I have started working on developing reconstruction algorithms for the FCC IDEA detector. We are considering Pandora PFA as our reconstruction framework, similar to CLD/ILD detectors, because many of the existing reconstruction algorithms in LCContent can be shared/reused despite the significant difference between the IDEA and other detector concepts.

Of course, however, the difference in the detector concept would require some amount of development in Pandora SDK. This PR contains:

a. Add the parent address for `pandora::Cluster` object. In the IDEA detector concept, the main calorimeter (dual-readout calorimeter) has no longitudinal segmentation. Therefore, the 'cone-based' clustering algorithms in LCContent, which were used for CALICE-like calorimeters, cannot be applied. Instead, we do the clustering in advance of running Pandora (topological clustering, which purely relies on the detector geometry/topology). The existing clusters are provided to Pandora using an external clustering algorithm (I am currently using the following Pandora algorithm [[link](https://github.com/SanghyunKo/k4GaudiPandora/blob/port-pandora-IDEA/k4GaudiPandora/src/DDExternalClusterCreator.cc)]).

However, unlike `pandora::CaloHit`, the `pandora::Cluster` has no member variable for the parent object address, so linking back to the cluster object (EDM4hep in our case) in the user framework is tricky. So adding a member for the parent address would make things a lot easier for the detectors that process clustering outside Pandora.

b. Add `SCINTILLATION` and `CHERENKOV` in the hit types enum. The dual-readout calorimeter uses a different technique to distinguish EM/hadronic showers. For example, instead of EM energy = ΣECAL energy & Hadronic energy = ΣHCAL energy, it would be something like:
```
S/E = (h/e)_{S} + f_{em}[1-(h/e)_{S}]
C/E = (h/e)_{C} + f_{em}[1-(h/e)_{C}]
```
where `S` and `C` are scintillation and Cherenkov channel energies, `E` is the anticipated truth energy, `f_{em}` is the EM fraction in the shower, and `h/e_{S}` and `h/e_{C}` are the empirical response ratio to the hadronic shower with respect to the EM shower for each scintillation and Cherenkov channel. So having enums for these would make it a lot easier to develop PID in Pandora algorithm for the dual-readout calorimeter.

We can discuss either in this thread or via offline at the upcoming [particle flow workshop](https://indico.cern.ch/event/1567387/) at CERN.