### PR TITLE
Add hit type enums for the dual-readout calorimeter

### DIFF
--- a/include/Pandora/PandoraEnumeratedTypes.h
+++ b/include/Pandora/PandoraEnumeratedTypes.h
@@ -71,6 +71,8 @@ enum HitType
     TPC_VIEW_V,
     TPC_VIEW_W,
     TPC_3D,
+    SCINTILLATION,
+    CHERENKOV,
     HIT_CUSTOM
 };
 

--- a/include/Pandora/PandoraEnumeratedTypes.h
+++ b/include/Pandora/PandoraEnumeratedTypes.h
@@ -71,8 +71,8 @@ enum HitType
     TPC_VIEW_V,
     TPC_VIEW_W,
     TPC_3D,
-    SCINTILLATION,
-    CHERENKOV,
+    DRC_SCINT,
+    DRC_CHEREN,
     HIT_CUSTOM
 };
 


### PR DESCRIPTION
Add `SCINTILLATION` and `CHERENKOV` in the hit type enums. The dual-readout calorimeter uses a different technique to distinguish EM/hadronic showers. For example, instead of EM energy = ΣECAL energy & Hadronic energy = ΣHCAL energy, the dual-readout calorimeter measures EM fraction of the shower by:
```
S/E = (h/e)_{S} + f_{em}[1-(h/e)_{S}]
C/E = (h/e)_{C} + f_{em}[1-(h/e)_{C}]
```
where S and C are scintillation and Cherenkov channel energies, E is the anticipated truth energy, `f_{em}` is the EM fraction in the shower, and `h/e_{S}` and `h/e_{C}` are the empirical response ratio to the hadronic shower with respect to the EM shower for each scintillation and Cherenkov channel. It would be useful to have enums for the detector families that use the dual-readout principle.

