### PR TITLE
Fix a warning about throw() being deprecated

### DIFF
--- a/include/Pandora/StatusCodes.h
+++ b/include/Pandora/StatusCodes.h
@@ -162,9 +162,9 @@ public:
     StatusCodeException(const StatusCode statusCode);
 
     /**
-     *  @brief  Constructor
+     *  @brief  Destructor
      */
-    ~StatusCodeException() throw();
+    ~StatusCodeException() noexcept = default;
 
     /**
      *  @brief  Get status code
@@ -214,12 +214,6 @@ inline StatusCodeException::StatusCodeException(const StatusCode statusCode) :
 
     free(stackStrings); // malloc()ed by backtrace_symbols
 #endif
-}
-
-//------------------------------------------------------------------------------------------------------------------------------------------
-
-inline StatusCodeException::~StatusCodeException() throw()
-{
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
`throw()` has been deprecated since C++11 and the compiler tells us to use `noexcept` instead. In addition, since the destructor doesn't do anything special, it can be set to `default`.

This is the warning:

``` cpp
/PandoraPFA/install/include/Pandora/StatusCodes.h:185:52: warning: dynamic exception specifications are deprecated [-Wdeprecated-dynamic-exception-spec]
  185 | inline StatusCodeException::~StatusCodeException() throw()
      |                                                    ^~~~~~~
/PandoraPFA/install/include/Pandora/StatusCodes.h:185:52: note: use 'noexcept' instead
  185 | inline StatusCodeException::~StatusCodeException() throw()
      |                                                    ^~~~~~~
      |                                                    noexcept

```