### PR TITLE
More error information for XML parsing errors

### DIFF
--- a/src/Pandora/Pandora.cc
+++ b/src/Pandora/Pandora.cc
@@ -143,7 +143,10 @@ StatusCode Pandora::ReadSettings(const std::string &xmlFileName)
 
         if (!xmlDocument.LoadFile())
         {
-            std::cout << "Pandora::ReadSettings - Invalid xml file." << std::endl;
+            std::cout << "Pandora::ReadSettings - Invalid xml file.\n" 
+                      << "    Error: " << xmlDocument.ErrorDesc() << "\n"
+                      << "    File:  " << xmlFileName
+                      << " line#: " << xmlDocument.ErrorRow() << std::endl;
             throw StatusCodeException(STATUS_CODE_FAILURE);
         }
 


### PR DESCRIPTION
When/if your xml is wrong the output will now look like this
```
Pandora::ReadSettings - Invalid xml file.
    Error: Error reading end tag.
    File:  ./My_PandoraSettings_Master_XmlReaderTests_DUNEFD.xml line#: 45
Failure in reading pandora settings, STATUS_CODE_FAILURE
PandoraApi::ReadSettings(*pPrimaryPandora, parameters.m_settingsFile) throw STATUS_CODE_FAILURE
    in function: CreatePandoraInstances
    in file:     /storage/epp2/phsajw/pandora_build7/LArReco/test/PandoraInterface.cxx line#: 104
Pandora StatusCodeException: STATUS_CODE_FAILURE
```
or for the Neutrino xml, this
```
Pandora::ReadSettings - Invalid xml file.
    Error: Error reading end tag.
    File:  ./My_PandoraSettings_Neutrino_XmlReaderTests_DUNEFD.xml line#: 136
Failure in reading pandora settings, STATUS_CODE_FAILURE
PandoraApi::ReadSettings(*pPandora, settingsFile) throw STATUS_CODE_FAILURE
    in function: CreateWorkerInstance
    in file:     /storage/epp2/phsajw/pandora_build7/LArContent/larpandoracontent/LArControlFlow/MasterAlgorithm.cc line#: 1051
MasterAlgorithm: Exception during initialization of worker instances STATUS_CODE_FAILURE
this->InitializeWorkerInstances() return STATUS_CODE_FAILURE
    in function: Run
    in file:     /storage/epp2/phsajw/pandora_build7/LArContent/larpandoracontent/LArControlFlow/MasterAlgorithm.cc line#: 158
iter->second->Run() throw STATUS_CODE_FAILURE
    in function: RunAlgorithm
    in file:     /storage/epp2/phsajw/pandora_build7/PandoraSDK/src/Api/PandoraContentApiImpl.cc line#: 263
Failure in algorithm Alg0003, LArDLMaster, STATUS_CODE_FAILURE
```
. The error message, file, and line# under the `Pandora::ReadSettings - Invalid xml file.` are new and I think helpful for tracking down typos.